### PR TITLE
14 message env

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cnd
 Title: Create and Register Conditions
-Version: 0.1.0.9000
+Version: 0.1.0.9001
 Authors@R: 
     person(
       "Jordan Mark", "Barbone", , 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ URL: https://jmbarbone.github.io/cnd/, https://github.com/jmbarbone/cnd
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Depends: 
     R (>= 3.6)
 Suggests: 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cnd (development version)
 
+- `cnd::condition_progenitor$message` no longer has its environment reset [#14](https://github.com/jmbarbone/cnd/issues/14)
+
 # cnd 0.1.0
 
 - Initial release

--- a/R/condition.R
+++ b/R/condition.R
@@ -122,7 +122,6 @@ condition <- function(
   # setting up an environment to track additional fields for
 
   condition_env <- new.env()
-  environment(message) <- condition_env
   assign("message", message, condition_env)
   assign("exports", exports, condition_env)
   assign("package", package, condition_env)

--- a/tests/testthat/_snaps/print.md
+++ b/tests/testthat/_snaps/print.md
@@ -77,9 +77,17 @@
          Component ".class": 1 string mismatch
          Component "class": 1 string mismatch
          Component "condition_function": target, current do not match when deparsed
-         Component ".class": 1 string mismatch
+         Component "message": Component "class": 1 string mismatch
+         Component "message": Component "original_class": 1 string mismatch
+         Component "message": Component "res": 1 string mismatch
+         Component "message": Component "res": target, current do not match when deparsed
          Component "class": 1 string mismatch
-         Component "condition_function": target, current do not match when deparsed
+         Component "condition_env": Component ".class": 1 string mismatch
+         Component "condition_env": Component "class": 1 string mismatch
+         Component "condition_env": Component "condition_function": target, current do not match when deparsed
+         Component "original_class": 1 string mismatch
+         Component "res": 1 string mismatch
+         Component "res": target, current do not match when deparsed
 
 ---
 


### PR DESCRIPTION
resolves #14

I think.  This is being tested on [mark@259-cnd](https://github.com/jmbarbone/mark/tree/259-cnd), which tries to employ an unexported function inside a `condition` message.
