### PR TITLE
Fix for testthat 3.3.0

### DIFF
--- a/tests/testthat/test-condition.R
+++ b/tests/testthat/test-condition.R
@@ -223,11 +223,9 @@ test_that("cnd(condition) handling", {
     class = "cnd::condition"
   )
 
-  expect_failure(
-    expect_condition(
-      expect_output(suppress_conditions(cnd(foo())), NA),
-      class = "cnd::condition"
-    )
+  expect_no_condition(
+    expect_output(suppress_conditions(cnd(foo())), NA),
+    class = "cnd::condition"
   )
 })
 


### PR DESCRIPTION
`expect_failure()` is now designed for testing custom expectations, so I switched to a simpler `expect_no_condition()` call.